### PR TITLE
Create cards from markdown file

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   '@radix-ui/react-dropdown-menu':
     specifier: ^2.0.6
     version: 2.0.6(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-label':
+    specifier: ^2.0.2
+    version: 2.0.2(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-navigation-menu':
     specifier: ^1.1.4
     version: 1.1.4(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
@@ -1430,6 +1433,27 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.74)(react@18.2.0)
       '@types/react': 18.2.74
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-label@2.0.2(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.74
+      '@types/react-dom': 18.2.24
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@radix-ui/react-menu@2.0.6(@types/react-dom@18.2.24)(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0):

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/utils/ui";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/src/hooks/card/use-create-many-card.ts
+++ b/src/hooks/card/use-create-many-card.ts
@@ -1,7 +1,8 @@
-import { ReactQueryOptions, trpc } from "@/utils/trpc";
+import { ReactQueryOptions, RouterInputs, trpc } from "@/utils/trpc";
 
 type CreateManyMutationOptions = ReactQueryOptions["card"]["createMany"];
 type CreateManyMutation = ReturnType<typeof trpc.card.createMany.useMutation>;
+export type CreateManyMutationInput = RouterInputs["card"]["createMany"];
 
 /**
  * Hook to create many cards at once.

--- a/src/utils/obsidian-parse.ts
+++ b/src/utils/obsidian-parse.ts
@@ -1,0 +1,36 @@
+// Obsidian spaced repetition uses a simple parser.
+// Multiline cards are separated by a separator "?" or "??".
+// The front and back of the card are the line before and after the separator,
+// until the next newline or the end of the file.
+// We don't use the same parser as `obsidian-spaced-repetition` as that is
+// overkill for extracting the cards.
+
+import { type CreateManyMutationInput } from "@/hooks/card/use-create-many-card";
+
+const MULTILINE_SEPARATOR = "?";
+
+export function extractCardContentFromMarkdownString(
+  markdown: string,
+): CreateManyMutationInput {
+  const mdReplacedNewlines = markdown.replace(/\r\n/g, "\n");
+  const lines = mdReplacedNewlines.split("\n");
+
+  const contents = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line !== MULTILINE_SEPARATOR) {
+      continue;
+    }
+
+    const question = lines[i - 1];
+    const answer = lines[i + 1];
+
+    if (!question || !answer) {
+      continue;
+    }
+
+    contents.push({ question, answer });
+  }
+
+  return contents;
+}


### PR DESCRIPTION
This PR adds support for batch creating cards by uploading a markdown file.

Currently, only multiline-separators are supported