### PR TITLE
Import cards from Obsidian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Local data
+data/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "db:studio": "drizzle-kit studio",
     "db:push": "drizzle-kit push:sqlite",
     "db:seed": "tsx --env-file=.env src/scripts/seed.ts",
-    "db:wipe": "tsx --env-file=.env src/scripts/wipe.ts"
+    "db:wipe": "tsx --env-file=.env src/scripts/wipe.ts",
+    "obsidian:export": "tsx src/scripts/export.ts",
+    "obsidian:import": "tsx --env-file=.env src/scripts/import.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -76,6 +78,7 @@
     "drizzle-kit": "^0.20.14",
     "eslint": "^8",
     "eslint-config-next": "14.1.4",
+    "gray-matter": "^4.0.3",
     "postcss": "^8",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ devDependencies:
   eslint-config-next:
     specifier: 14.1.4
     version: 14.1.4(eslint@8.57.0)(typescript@5.4.4)
+  gray-matter:
+    specifier: ^4.0.3
+    version: 4.0.3
   postcss:
     specifier: ^8
     version: 8.4.38
@@ -2235,6 +2238,12 @@ packages:
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
@@ -3438,6 +3447,12 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
@@ -3478,6 +3493,13 @@ packages:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
     dependencies:
       type: 2.7.2
+    dev: true
+
+  /extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extendable: 0.1.1
     dev: true
 
   /extend@3.0.2:
@@ -3744,6 +3766,16 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+    dev: true
+
   /hanji@0.0.5:
     resolution: {integrity: sha512-Abxw1Lq+TnYiL4BueXqMau222fPSPMFtya8HdpWsz/xVAhifXou71mPh/kY2+08RgFcVccjG3uZHs6K5HAe3zw==}
     dependencies:
@@ -3905,6 +3937,11 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.2
+    dev: true
+
+  /is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /is-extglob@2.1.1:
@@ -4069,6 +4106,14 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: true
+
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -4118,6 +4163,11 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
+
+  /kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /language-subtag-registry@0.3.22:
@@ -5507,6 +5557,14 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
+  /section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+    dev: true
+
   /seedrandom@3.0.5:
     resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
     dev: false
@@ -5616,6 +5674,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -5699,6 +5761,11 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
+
+  /strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}

--- a/src/app/decks/layout.tsx
+++ b/src/app/decks/layout.tsx
@@ -1,5 +1,5 @@
-const containerClasses =
-  "col-start-1 col-end-13 xl:col-start-3 xl:col-end-11 grid grid-cols-8 gap-x-4 pt-6 pb-12";
+import { gridChildContentGrid } from "@/components/ui/grid";
+import { cn } from "@/utils/ui";
 
 function Layout({
   children,
@@ -7,9 +7,7 @@ function Layout({
   children: React.ReactNode;
 }>) {
   return (
-    <main className="col-span-12 grid grid-cols-12">
-      <div className={containerClasses}>{children}</div>
-    </main>
+    <main className={cn(gridChildContentGrid, "pb-12 pt-6")}>{children}</main>
   );
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/utils/ui";
 import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { baseGrid } from "@/components/ui/grid";
 
 export const metadata: Metadata = {
   title: "Spaced",
@@ -23,7 +24,8 @@ function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
-          "grid min-h-screen grid-cols-12 grid-rows-[min-content_1fr] gap-x-6 bg-background px-2 font-sans antialiased sm:px-6",
+          baseGrid,
+          "min-h-screen grid-rows-[min-content_1fr] bg-background font-sans antialiased",
           inter.variable,
         )}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 import FlashcardBox from "@/components/flashcard/flashcard-box";
+import { gridChildContentGrid, gridChildGrid } from "@/components/ui/grid";
+import { cn } from "@/utils/ui";
 
 export default async function Home() {
   return (
-    <main className="col-span-12 grid h-full grid-cols-12 gap-x-4">
+    <main className={cn(gridChildContentGrid, "h-full")}>
       <FlashcardBox />
     </main>
   );

--- a/src/components/decks/create-deck-form.tsx
+++ b/src/components/decks/create-deck-form.tsx
@@ -40,7 +40,7 @@ export function CreateDeckForm() {
   };
 
   return (
-    <UiCard className="col-start-1 col-end-9 self-start border-0 sm:col-start-2 sm:col-end-8 md:border lg:col-start-3 lg:col-end-7">
+    <UiCard className="col-span-12 w-full max-w-xl self-start justify-self-center border-0 md:border">
       <UiCardHeader className="px-2 md:px-6">
         <UiCardTitle>Create</UiCardTitle>
         <UiCardDescription>

--- a/src/components/decks/deck-box.tsx
+++ b/src/components/decks/deck-box.tsx
@@ -5,11 +5,11 @@ import { trpc } from "@/utils/trpc";
 import { Diamond } from "lucide-react";
 
 const sectionClasses =
-  "col-span-8 grid grid-cols-1 gap-x-4 gap-y-4 lg:grid-cols-2";
+  "col-span-12 grid grid-cols-1 gap-x-4 gap-y-4 md:grid-cols-2";
 
 function Title() {
   return (
-    <div className="col-span-8 mb-4 flex items-center pl-2">
+    <div className="col-span-12 mb-4 flex items-center pl-2">
       <h1 className="text-4xl font-bold md:text-5xl">Decks</h1>
       <Diamond className="ml-3 h-8 w-8 text-accent-foreground md:h-10 md:w-10" />
     </div>

--- a/src/components/decks/deck-cards.tsx
+++ b/src/components/decks/deck-cards.tsx
@@ -15,11 +15,11 @@ type Props = {
 };
 
 const containerClasses =
-  "col-span-8 grid w-full grid-cols-1 gap-4 md:grid-cols-2";
+  "col-span-12 grid w-full grid-cols-1 gap-4 md:grid-cols-2";
 
 function Title({ title }: { title: string }) {
   return (
-    <div className="col-span-8 mb-2 flex items-center pl-2">
+    <div className="col-span-12 mb-4 flex items-center pl-2">
       <h1 className="text-4xl font-bold md:text-5xl">{title}</h1>
       <Diamond className="ml-3 h-8 w-8 text-accent-foreground md:h-10 md:w-10" />
 
@@ -75,7 +75,7 @@ export default function DeckCards({ deckId }: Props) {
   return (
     <>
       <Title title={deck.name} />
-      <section className="col-span-8 mb-6 flex w-full flex-col gap-y-4 pl-2">
+      <section className="col-span-12 mb-6 flex w-full flex-col gap-y-4 pl-2">
         <div className="flex gap-x-4">
           <p className="flex items-center text-xl">
             <NotebookTabs className="mr-2 h-6 w-6" />
@@ -106,7 +106,7 @@ export default function DeckCards({ deckId }: Props) {
         onClick={() => fetchNextPage()}
         disabled={isFetchingNextPage}
         className={cn(
-          "col-span-8 mt-4 justify-self-stretch sm:justify-self-end",
+          "col-span-12 mt-4 justify-self-stretch sm:justify-self-end",
           !hasNextPage && "hidden",
         )}
       >

--- a/src/components/flashcard/create-flashcard-form.tsx
+++ b/src/components/flashcard/create-flashcard-form.tsx
@@ -80,7 +80,7 @@ export default function CreateFlashcardForm() {
 
   return (
     <UiCard
-      className="col-start-1 col-end-9 self-start border-0 sm:col-start-2 sm:col-end-8 md:border lg:col-start-3 lg:col-end-7"
+      className="col-span-12 w-full max-w-xl self-start justify-self-center border-0 md:border"
       ref={cardRef}
     >
       <UiCardHeader className="px-2 md:px-6">
@@ -92,7 +92,7 @@ export default function CreateFlashcardForm() {
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
-          <UiCardContent className="flex min-h-96 flex-col gap-y-4 px-2 md:px-6">
+          <UiCardContent className="flex h-full flex-col gap-y-4 px-2 md:px-6">
             <FormSelect
               name="deckIds"
               label="Deck"
@@ -108,6 +108,8 @@ export default function CreateFlashcardForm() {
               label="Question"
               form={form}
               disabled={isLoading}
+              border={true}
+              className="max-h-96 overflow-y-auto"
             />
             <FormMarkdownEditor
               key={markdownEditorKey + "answer"}
@@ -115,6 +117,8 @@ export default function CreateFlashcardForm() {
               label="Answer"
               form={form}
               disabled={isLoading}
+              border={true}
+              className="max-h-96 overflow-y-auto"
             />
           </UiCardContent>
           <UiCardFooter className="px-2 md:px-6">

--- a/src/components/flashcard/flashcard-simple.tsx
+++ b/src/components/flashcard/flashcard-simple.tsx
@@ -17,21 +17,20 @@ export function FlashcardSimpleSkeleton() {
 export default function FlashcardSimple({ card, cardContent }: Props) {
   return (
     <UiCard className="flex w-full flex-col gap-y-4">
-      <UiCardContent className="mt-6">
-        <ScrollArea className="h-60">
-          <div>
-            <h2 className="mb-2 text-xl font-semibold lg:text-2xl">Question</h2>
-            <p className="text-md">{cardContent.question}</p>
-          </div>
+      <UiCardContent className="mt-6 h-72 overflow-y-auto py-0">
+        <div>
+          <h2 className="mb-2 text-xl font-semibold lg:text-2xl">Question</h2>
+          <p className="text-md">{cardContent.question}</p>
+        </div>
 
-          <hr className="mx-auto my-6 w-16" />
+        <hr className="mx-auto my-6 w-16" />
 
-          <div>
-            <h2 className="mb-2 text-xl font-semibold lg:text-2xl">Answer</h2>
-            <p className="text-md">{cardContent.answer}</p>
-          </div>
-        </ScrollArea>
+        <div>
+          <h2 className="mb-2 text-xl font-semibold lg:text-2xl">Answer</h2>
+          <p className="text-md">{cardContent.answer}</p>
+        </div>
       </UiCardContent>
+
       <UiCardFooter className="flex">
         <TimeIconText date={card.createdAt} />
         <FlashcardState className="ml-auto" state={card.state} />

--- a/src/components/flashcard/flashcard.tsx
+++ b/src/components/flashcard/flashcard.tsx
@@ -127,11 +127,8 @@ export default function Flashcard({
   });
 
   return (
-    <div
-      className="col-start-1 col-end-13 grid grid-cols-8 grid-rows-[auto_1fr] gap-x-4 gap-y-2 xl:col-start-3 xl:col-end-11"
-      ref={cardRef}
-    >
-      <div className="col-start-1 col-end-9 flex h-24 flex-wrap items-end justify-center gap-x-2">
+    <div className="col-span-12 flex flex-col gap-x-4 gap-y-4" ref={cardRef}>
+      <div className="col-span-8 flex h-24 flex-wrap items-end justify-center gap-x-2">
         {/* Stats and review information */}
         <CardCountBadge stats={stats} />
         <FlashcardState
@@ -143,7 +140,6 @@ export default function Flashcard({
         <div className="mr-auto w-screen sm:w-0"></div>
 
         {/* Icons */}
-
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger className="cursor-text" onClick={handleSkip}>

--- a/src/components/form/form-markdown-editor.tsx
+++ b/src/components/form/form-markdown-editor.tsx
@@ -13,6 +13,7 @@ type FormMarkdownEditorProps<TFieldValues extends FieldValues> =
   FormInputProps<TFieldValues> & {
     editing?: boolean;
     className?: string;
+    border?: boolean;
   };
 
 /**
@@ -30,6 +31,7 @@ export function FormMarkdownEditor<TFieldValues extends FieldValues>({
   disabled,
   label,
   className,
+  border,
 }: FormMarkdownEditorProps<TFieldValues>) {
   return (
     <FormField
@@ -40,7 +42,7 @@ export function FormMarkdownEditor<TFieldValues extends FieldValues>({
         <FormItem className={className}>
           {label && <FormLabel>{label}</FormLabel>}
           <FormControl>
-            <MarkdownEditor {...field} />
+            <MarkdownEditor border={border} {...field} />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@/utils/ui";
 import {
   Editor,
   defaultValueCtx,
@@ -27,9 +28,8 @@ type Props = {
   value: string;
   disabled?: boolean;
   onChange?: (content: string) => void;
+  border?: boolean;
 };
-
-const editorClasses = "mx-auto outline-none px-3 py-2";
 
 export function getMarkdown(editor: Editor | undefined) {
   if (!editor) return "";
@@ -41,7 +41,12 @@ export function getMarkdown(editor: Editor | undefined) {
   });
 }
 
-const MilkdownEditor = ({ disabled, value, onChange }: Props) => {
+const MilkdownEditor = ({ disabled, value, onChange, border }: Props) => {
+  const editorClasses = cn(
+    "mx-auto outline-none px-3 py-2",
+    border && "border border-input rounded-sm",
+  );
+
   // Create a ref to store the current editing state
   const disabledRef = useRef(disabled);
   useEffect(() => {

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -114,7 +114,7 @@ export function NavigationBar() {
       <NavigationMenuList className="hidden md:flex">
         <NavigationMenuItem>
           <Link href="/" legacyBehavior passHref>
-            <NavigationMenuLink className={"flex justify-start"}>
+            <NavigationMenuLink className={"mr-2 flex justify-start"}>
               <Telescope className="h-6 w-6 xs:mr-2" strokeWidth={1.5} />
               <span className="hidden text-lg font-semibold xs:block">
                 spaced

--- a/src/components/ui/grid.ts
+++ b/src/components/ui/grid.ts
@@ -1,0 +1,24 @@
+// Base grid styles
+// This project uses a 12-column grid system.
+
+import { cn } from "@/utils/ui";
+
+export const grid = "grid grid-cols-12 gap-x-6 items-start";
+export const baseGrid = cn(grid, "px-2 sm:px-6");
+export const gridChild = "col-start-1 col-end-13";
+
+/**
+ * A grid child that takes up the full width of the grid
+ * This is used for the containers of a page.
+ */
+export const gridChildGrid = cn(gridChild, grid);
+
+/**
+ * A grid child that covers the main content area of the page.
+ * On laptop screens, the main content takes up 8 columns.
+ * On smaller screens, the main content takes up 12 columns.
+ */
+export const gridChildContentGrid = cn(
+  gridChildGrid,
+  "xl:col-start-3 xl:col-end-11 xl:grid-cols-8",
+);

--- a/src/hooks/card/use-grade-card.ts
+++ b/src/hooks/card/use-grade-card.ts
@@ -44,7 +44,6 @@ export function useGradeCard(options?: GradeMutationOptions): GradeMutation {
       )
         return;
 
-      console.log("Invalidated");
       await utils.card.sessionData.invalidate();
     },
 

--- a/src/hooks/card/use-suspend.card.ts
+++ b/src/hooks/card/use-suspend.card.ts
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 type SuspendCardMutationOptions = ReactQueryOptions["card"]["suspend"];
 type SuspendMutation = ReturnType<typeof trpc.card.suspend.useMutation>;
 
+const THRESHOLD_FOR_REFETCH = 10;
+
 export function useSuspendCard(
   options?: SuspendCardMutationOptions,
 ): SuspendMutation {
@@ -21,6 +23,15 @@ export function useSuspendCard(
 
       const nextSessionData = getNextSessionData(sessionData, id);
       utils.card.sessionData.setData(undefined, nextSessionData);
+
+      if (
+        !sessionData ||
+        sessionData.reviewCards.length + sessionData.newCards.length >
+          THRESHOLD_FOR_REFETCH
+      )
+        return;
+
+      await utils.card.sessionData.invalidate();
 
       return {
         previousSession: sessionData,

--- a/src/scripts/export.ts
+++ b/src/scripts/export.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import matter from "gray-matter";
+import { extractCardContentFromMarkdownString } from "@/utils/obsidian-parse";
+
+async function getFilenamesWithExtension(
+  folder: string,
+  callback: (filename: string) => void,
+  extension: string = "",
+) {
+  const files = await fs.readdir(folder);
+
+  for (const file of files) {
+    const filePath = path.join(folder, file);
+    const stat = await fs.stat(filePath);
+    if (stat.isDirectory()) {
+      await getFilenamesWithExtension(filePath, callback, extension);
+      continue;
+    }
+
+    const isTargetFile = file.endsWith(extension);
+    if (!isTargetFile) {
+      continue;
+    }
+
+    callback(filePath);
+  }
+}
+
+// We want to transform the data into the following format.
+// Tags -> deck name
+// The deck names are transformed to a generated UUID
+// The cards in the deck are generated with a Q/A format
+// Each card has a deckIds field that contains the UUID of the deck
+type Card = {
+  question: string;
+  answer: string;
+  deckIds: string[];
+};
+
+type ExportDataJson = {
+  decks: string[];
+  cards: Card[];
+};
+
+const pathToMetadata = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "data",
+  "metadata.json",
+);
+
+async function readMetadata(): Promise<{
+  folder: string;
+  tags: string[];
+}> {
+  const metadata = await fs.readFile(pathToMetadata, "utf-8");
+  const parsed = JSON.parse(metadata);
+  if (!parsed.folder) {
+    throw new Error("Folder not found in metadata.json");
+  }
+
+  if (!Array.isArray(parsed.tags)) {
+    throw new Error("Tags not found in metadata.json");
+  }
+
+  return parsed;
+}
+
+/**
+ * Exports cards from markdown files to a JSON file.
+ * The JSON file contains the decks and cards in the format
+ *
+ * Add the path to your Obsidian vault in the `metadata.json` file.
+ *
+ * @example
+ * ```json
+ * {
+ *  "folder": "/path/to/your/obsidian/vault",
+ *  "tags": ["deck1", "deck2", "deck3"]
+ * }
+ * ```
+ */
+async function main() {
+  const filenames: string[] = [];
+  const { folder, tags } = await readMetadata();
+
+  await getFilenamesWithExtension(
+    folder,
+    (filename) => filenames.push(filename),
+    ".md",
+  );
+
+  const decks = new Set<string>(tags);
+  const allCards: Card[] = [];
+
+  for (let i = 0; i < filenames.length; i++) {
+    const filename = filenames[i];
+    try {
+      const markdownString = await fs.readFile(filename, "utf-8");
+      const parsed = matter(markdownString);
+
+      // We don't create cards if there are no decks
+      if (!parsed?.data?.tags) {
+        continue;
+      }
+
+      const tags: string[] = parsed.data.tags?.filter(
+        (tag: unknown): tag is string =>
+          typeof tag === "string" && decks.has(tag),
+      );
+
+      if (tags.length === 0) {
+        continue;
+      }
+
+      const cards = extractCardContentFromMarkdownString(parsed.content);
+      const cardsWithDeck: Card[] = cards.map((card) => ({
+        ...card,
+        deckIds: tags,
+      }));
+
+      allCards.push(...cardsWithDeck);
+    } catch (err) {
+      console.error(`Error while reading ${filename}: ${err}`);
+    }
+  }
+
+  const exportData: ExportDataJson = {
+    decks: [...decks],
+    cards: allCards,
+  };
+
+  const currentDir = path.resolve(__dirname);
+  await fs.writeFile(
+    path.join(currentDir, "..", "..", "data", "export.json"),
+    JSON.stringify(exportData, null, 2),
+  );
+
+  console.log(`Exported ${allCards.length} cards to ${currentDir}`);
+}
+
+main();

--- a/src/scripts/import.ts
+++ b/src/scripts/import.ts
@@ -1,0 +1,69 @@
+import path from "path";
+import fs from "node:fs/promises";
+import z from "zod";
+import db from "@/db";
+import { NewDeck, cardContents, cards, cardsToDecks, decks } from "@/schema";
+import { success } from "@/utils/format";
+import { newCardWithContent } from "@/utils/fsrs";
+
+const currentDir = path.resolve(__dirname);
+const filename = path.join(currentDir, "..", "..", "data", "export.json");
+
+const schema = z.object({
+  decks: z.array(z.string()),
+  cards: z.array(
+    z.object({
+      deckIds: z.array(z.string()),
+      question: z.string(),
+      answer: z.string(),
+    }),
+  ),
+});
+
+async function main() {
+  const stat = await fs.stat(filename);
+  if (!stat.isFile()) {
+    throw new Error(`File ${filename} does not exist`);
+  }
+
+  const file = await fs.readFile(filename, "utf-8");
+  const data = JSON.parse(file);
+  const parsed = schema.parse(data);
+
+  console.log(`Importing ${parsed.decks.length} decks`);
+  const decksToInsert = parsed.decks.map((deck) => ({
+    id: crypto.randomUUID(),
+    name: deck,
+  })) satisfies NewDeck[];
+  await db.insert(decks).values(decksToInsert);
+  console.log(success`Imported ${parsed.decks.length} decks`);
+
+  console.log(`Importing ${parsed.cards.length} cards`);
+  const batchSize = 250;
+
+  for (let i = 0; i < parsed.cards.length; i += batchSize) {
+    const slicedCards = parsed.cards.slice(i, i + batchSize);
+    const cardWithContents = slicedCards.map((card) => ({
+      ...newCardWithContent(card.question, card.answer),
+      deckIds: card.deckIds,
+    }));
+
+    const cardsToInsert = cardWithContents.map(({ card }) => card);
+    const cardContentsToInsert = cardWithContents.map(
+      ({ cardContent }) => cardContent,
+    );
+    const cardsToDecksToInsert = cardWithContents.flatMap(({ card, deckIds }) =>
+      deckIds.map((deckId) => ({ cardId: card.id, deckId })),
+    );
+
+    await db.insert(cards).values(cardsToInsert);
+    await db.insert(cardContents).values(cardContentsToInsert);
+    await db.insert(cardsToDecks).values(cardsToDecksToInsert);
+    console.log(
+      success`Imported ${i + 1}-${Math.min(i + batchSize, parsed.cards.length)} cards`,
+    );
+  }
+  console.log(success`Imported ${parsed.cards.length} cards`);
+}
+
+main();

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -19,7 +19,7 @@ import { faker } from "@faker-js/faker";
 import { add, isBefore, sub } from "date-fns";
 import { createEmptyCard } from "ts-fsrs";
 import { Card, CardContent, ReviewLog } from "../schema";
-import { wipeDatabase } from "@/scripts/wipe";
+import { wipeDatabase } from "@/scripts/utils";
 
 // Data generated using the faker-js library.
 // See https://fakerjs.dev/api/

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -1,0 +1,12 @@
+import db from "@/db";
+import { cardContents, cards, decks, reviewLogs } from "@/schema";
+import { success } from "@/utils/format";
+
+export async function wipeDatabase() {
+  console.log("Deleting all data from the database");
+  await db.delete(reviewLogs).all();
+  await db.delete(cardContents).all();
+  await db.delete(cards).all();
+  await db.delete(decks).all();
+  console.log(success`Deleted all data from the database`);
+}

--- a/src/scripts/wipe.ts
+++ b/src/scripts/wipe.ts
@@ -1,12 +1,3 @@
-import db from "@/db";
-import { cardContents, cards, decks, reviewLogs } from "@/schema";
-import { success } from "@/utils/format";
+import { wipeDatabase } from "@/scripts/utils";
 
-export async function wipeDatabase() {
-  console.log("Deleting all data from the database");
-  await db.delete(reviewLogs).all();
-  await db.delete(cardContents).all();
-  await db.delete(cards).all();
-  await db.delete(decks).all();
-  console.log(success`Deleted all data from the database`);
-}
+wipeDatabase();

--- a/src/server/routers/card.ts
+++ b/src/server/routers/card.ts
@@ -67,7 +67,7 @@ async function getNewCards(): Promise<SessionCard[]> {
     .orderBy(desc(reviewLogs.createdAt))
     .groupBy(reviewLogs.cardId);
 
-  const numLearnToday = numLearnTodayRes[0].total;
+  const numLearnToday = numLearnTodayRes[0]?.total ?? 0;
   if (typeof numLearnToday !== "number") {
     throw new TRPCError({
       message: "Failed to get the number of cards learned today",

--- a/src/server/routers/card.ts
+++ b/src/server/routers/card.ts
@@ -205,38 +205,39 @@ export const cardRouter = router({
         ({ cardContent }) => cardContent,
       );
 
-      const res = await db.transaction(async (tx) => {
-        const insertedCards = await tx
-          .insert(cards)
-          .values(cardsToInsert)
-          .returning();
-        const insertedCardContents = await tx
-          .insert(cardContents)
-          .values(cardContentsToInsert)
-          .returning();
-
-        if (deckIds && deckIds.length > 0) {
-          console.log("Adding cards to decks");
-          const cardsToDecksToInsert = deckIds.flatMap((deckId) =>
-            insertedCards.map((card) => ({
-              cardId: card.id,
-              deckId,
-            })),
-          ) satisfies NewCardsToDecks[];
-          await tx.insert(cardsToDecks).values(cardsToDecksToInsert);
-          console.log(
-            success`Added ${cardsToDecksToInsert.length} cards to decks`,
-          );
-        }
-
-        return insertedCards.map((card, index) => ({
-          cards: card,
-          card_contents: insertedCardContents[index],
-        }));
-      });
+      // When using drizzle's transaction, we bump into an issue
+      // of error when batch inserting.
+      // For now, let's now use transactions and instead just insert normally
+      // This is a bit risky, but we can't do much about it for now.
+      // See https://github.com/tursodatabase/libsql-client-ts/issues/177
+      const insertedCards = await db
+        .insert(cards)
+        .values(cardsToInsert)
+        .returning();
+      const insertedCardContents = await db
+        .insert(cardContents)
+        .values(cardContentsToInsert)
+        .returning();
+      if (deckIds && deckIds.length > 0) {
+        console.log("Adding cards to decks");
+        const cardsToDecksToInsert = deckIds.flatMap((deckId) =>
+          insertedCards.map((card) => ({
+            cardId: card.id,
+            deckId,
+          })),
+        ) satisfies NewCardsToDecks[];
+        await db.insert(cardsToDecks).values(cardsToDecksToInsert);
+        console.log(
+          success`Added ${cardsToDecksToInsert.length} cards to decks`,
+        );
+      }
 
       console.log(success`Added ${cardInputs.length} cards`);
-      return res;
+
+      return insertedCards.map((card, index) => ({
+        cards: card,
+        card_contents: insertedCardContents[index],
+      }));
     }),
 
   // Delete a card

--- a/src/utils/obsidian-parse.ts
+++ b/src/utils/obsidian-parse.ts
@@ -10,6 +10,7 @@ import { type CreateManyMutationInput } from "@/hooks/card/use-create-many-card"
 type CardInput = CreateManyMutationInput["cardInputs"][0];
 
 const MULTILINE_SEPARATOR = "?";
+const MULTILINE_REVERSED_SEPARATOR = "??";
 const SINGLELINE_SEPARATOR = "@@";
 
 function extractCardContentFromSingleLine(line: string): CardInput | undefined {
@@ -40,7 +41,7 @@ export function extractCardContentFromMarkdownString(
       continue;
     }
 
-    if (line !== MULTILINE_SEPARATOR) {
+    if (line !== MULTILINE_SEPARATOR && line !== MULTILINE_REVERSED_SEPARATOR) {
       continue;
     }
 
@@ -51,6 +52,9 @@ export function extractCardContentFromMarkdownString(
     }
 
     contents.push({ question, answer });
+    if (line === MULTILINE_REVERSED_SEPARATOR) {
+      contents.push({ question: answer, answer: question });
+    }
   }
 
   return contents;

--- a/src/utils/obsidian-parse.ts
+++ b/src/utils/obsidian-parse.ts
@@ -7,24 +7,45 @@
 
 import { type CreateManyMutationInput } from "@/hooks/card/use-create-many-card";
 
+type CardInput = CreateManyMutationInput["cardInputs"][0];
+
 const MULTILINE_SEPARATOR = "?";
+const SINGLELINE_SEPARATOR = "@@";
+
+function extractCardContentFromSingleLine(line: string): CardInput | undefined {
+  const [question, answer] = line.split(SINGLELINE_SEPARATOR);
+  if (!answer) {
+    return;
+  }
+
+  return {
+    question,
+    answer,
+  };
+}
 
 export function extractCardContentFromMarkdownString(
   markdown: string,
-): CreateManyMutationInput["cardInputs"] {
+): CardInput[] {
   const mdReplacedNewlines = markdown.replace(/\r\n/g, "\n");
   const lines = mdReplacedNewlines.split("\n");
 
   const contents = [];
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+
+    const content = extractCardContentFromSingleLine(line);
+    if (content) {
+      contents.push(content);
+      continue;
+    }
+
     if (line !== MULTILINE_SEPARATOR) {
       continue;
     }
 
     const question = lines[i - 1];
     const answer = lines[i + 1];
-
     if (!question || !answer) {
       continue;
     }


### PR DESCRIPTION
Fixes #52

This PR adds support for importing cards from Obsidian.
Currently, the way to import is to run the `pnpm obsidian:export` and `pnpm obsidian:import` locally.
Eventually, I should be able to extract the logic into an Obsidian plugin that can run on the device.

- **chore: update seed script**
- **feat: standardise grid styling**
- **feat: add singleline cards**
- **fix: fix issue with batch inserting**
- **feat: add export and import obsidian**
- **fix: update invalidation for suspend card**
