### PR TITLE
Add image upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Create a new turso database at https://turso.tech/app/databases
 TURSO_AUTH_TOKEN=
 TURSO_DATABASE_URL=
+# For uploading images to Cloudflare
+CLOUDFLARE_IMAGE_UPLOAD_WORKER_TOKEN=

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@milkdown/plugin-clipboard": "^7.3.6",
     "@milkdown/plugin-history": "^7.3.6",
     "@milkdown/plugin-listener": "^7.3.6",
+    "@milkdown/plugin-upload": "^7.3.6",
     "@milkdown/preset-commonmark": "^7.3.6",
     "@milkdown/preset-gfm": "^7.3.6",
     "@milkdown/prose": "^7.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   '@milkdown/plugin-listener':
     specifier: ^7.3.6
     version: 7.3.6(@milkdown/core@7.3.6)(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6)
+  '@milkdown/plugin-upload':
+    specifier: ^7.3.6
+    version: 7.3.6(@milkdown/core@7.3.6)(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6)
   '@milkdown/preset-commonmark':
     specifier: ^7.3.6
     version: 7.3.6(@milkdown/core@7.3.6)(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6)
@@ -961,6 +964,23 @@ packages:
       '@milkdown/utils': 7.3.6(@milkdown/core@7.3.6)(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6)
       '@types/lodash.debounce': 4.0.9
       lodash.debounce: 4.0.8
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@milkdown/transformer'
+    dev: false
+
+  /@milkdown/plugin-upload@7.3.6(@milkdown/core@7.3.6)(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6):
+    resolution: {integrity: sha512-s2zCez9tZmza2SlnVrEbqJ+PQWR869EBCcvhWs4FDe8caehDQ7CriQ65J7nwBK9JoU1kT+kDMithbVWIxLqRbQ==}
+    peerDependencies:
+      '@milkdown/core': ^7.2.0
+      '@milkdown/ctx': ^7.2.0
+      '@milkdown/prose': ^7.2.0
+    dependencies:
+      '@milkdown/core': 7.3.6(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6)
+      '@milkdown/ctx': 7.3.6
+      '@milkdown/exception': 7.3.6
+      '@milkdown/prose': 7.3.6
+      '@milkdown/utils': 7.3.6(@milkdown/core@7.3.6)(@milkdown/ctx@7.3.6)(@milkdown/prose@7.3.6)(@milkdown/transformer@7.3.6)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@milkdown/transformer'

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -1,5 +1,6 @@
 import { cardRouter } from "@/server/routers/card";
 import { deckRouter } from "@/server/routers/deck";
+import { imageRouter } from "@/server/routers/image";
 import { router, publicProcedure } from "@/server/trpc";
 import { success } from "@/utils/format";
 import { z } from "zod";
@@ -14,6 +15,7 @@ export const appRouter = router({
   }),
   card: cardRouter,
   deck: deckRouter,
+  image: imageRouter,
 });
 // Export type router type signature,
 // NOT the router itself.

--- a/src/server/routers/image.ts
+++ b/src/server/routers/image.ts
@@ -1,0 +1,81 @@
+import { publicProcedure, router } from "@/server/trpc";
+import { success } from "@/utils/format";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+// https://stackoverflow.com/questions/26667820/upload-a-base64-encoded-image-using-formdata
+function dataURItoBlob(dataURI: string) {
+  // convert base64 to raw binary data held in a string
+  // doesn't handle URLEncoded DataURIs - see SO answer #6850276 for code that does this
+  var byteString = atob(dataURI.split(",")[1]);
+
+  // separate out the mime component
+  var mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
+
+  // write the bytes of the string to an ArrayBuffer
+  var ab = new ArrayBuffer(byteString.length);
+
+  // create a view into the buffer
+  var ia = new Uint8Array(ab);
+
+  // set the bytes of the buffer to the correct values
+  for (var i = 0; i < byteString.length; i++) {
+    ia[i] = byteString.charCodeAt(i);
+  }
+
+  // write the ArrayBuffer to a blob, and you're done
+  var blob = new Blob([ab], { type: mimeString });
+  return blob;
+}
+
+const token = process.env.CLOUDFLARE_IMAGE_UPLOAD_WORKER_TOKEN;
+
+// TODO this token should be provided through context
+if (!token) {
+  throw new Error("Cloudflare image upload worker token must be provided.");
+}
+
+export const imageRouter = router({
+  // Image uploads from the markdown editor
+  upload: publicProcedure
+    .input(
+      z.object({
+        base64String: z.string(),
+        name: z.string(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { base64String, name } = input;
+      const file = dataURItoBlob(base64String);
+      const formData = new FormData();
+      formData.append("file", file, name);
+
+      console.log("Uploading image");
+      const res = await fetch("https://upload.zsheng.app/upload", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        method: "PUT",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to upload image",
+        });
+      }
+
+      const { imageLink } = await res.json();
+      if (typeof imageLink !== "string" || !imageLink) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to upload image",
+        });
+      }
+
+      console.log(success`Image uploaded: ${imageLink}`);
+
+      return imageLink as string;
+    }),
+});


### PR DESCRIPTION
Fixes #62

This PR adds image upload through a [Cloudflare Worker](https://github.com/zsh-eng/image-upload) which stores the images in an R2 bucket.
This solution works for small use cases like mine.

- **feat: add image upload**
- **chore: update .env.example**
