### PR TITLE
Fix issues with swiping and overflow

### DIFF
--- a/src/components/flashcard/main/answer-buttons.tsx
+++ b/src/components/flashcard/main/answer-buttons.tsx
@@ -64,7 +64,7 @@ export default function AnswerButtons({
   return (
     <div
       className={cn(
-        "grid h-full grid-cols-2 gap-x-2 gap-y-2 sm:h-12 sm:w-96 md:grid-cols-4",
+        "grid h-full grid-cols-2 gap-x-2 gap-y-2 shadow-sm sm:h-12 sm:w-96 md:grid-cols-4",
       )}
     >
       {open ? (
@@ -85,7 +85,7 @@ export default function AnswerButtons({
       ) : (
         <Button
           variant="secondary"
-          className="col-span-2 h-32 text-2xl sm:h-full sm:text-lg md:col-span-4"
+          className="col-span-2 h-32 text-2xl transition duration-300 hover:scale-105 sm:h-full sm:text-lg md:col-span-4"
           onClick={() => setOpen(true)}
         >
           Reveal

--- a/src/components/flashcard/main/editable-flashcard.tsx
+++ b/src/components/flashcard/main/editable-flashcard.tsx
@@ -25,7 +25,7 @@ export function EditableFlashcard({ form, setOpen, open, editing }: Props) {
     <Form {...form}>
       <div
         className={cn(
-          "col-span-8 flex h-full min-h-80 w-full items-center justify-center overflow-y-auto border border-input sm:col-span-4 sm:min-h-96",
+          "col-span-8 flex h-full min-h-80 w-full items-center justify-center overflow-y-auto rounded-md border border-input sm:col-span-4 sm:min-h-96",
           editing ? "bg-muted" : "",
         )}
         onClick={onContainerFocus}
@@ -35,7 +35,7 @@ export function EditableFlashcard({ form, setOpen, open, editing }: Props) {
 
       <div
         className={cn(
-          "relative col-span-8 flex h-full min-h-80 w-full items-center justify-center border border-input sm:col-span-4 sm:min-h-96",
+          "relative col-span-8 flex h-full min-h-80 w-full items-center justify-center rounded-md border border-input sm:col-span-4 sm:min-h-96",
           editing ? "bg-muted" : "",
         )}
         onClick={onContainerFocus}

--- a/src/components/flashcard/main/flashcard.tsx
+++ b/src/components/flashcard/main/flashcard.tsx
@@ -34,7 +34,7 @@ type Props = {
   onDelete: () => void;
 };
 
-const SWIPE_THRESHOLD = 120;
+const SWIPE_THRESHOLD = 40;
 const SWIPE_PADDING = 60;
 const ANIMATION_DURATION = 200;
 const SWIPE_DURATION = ANIMATION_DURATION + 500;
@@ -106,7 +106,7 @@ export default function Flashcard({
       const { deltaX: x, deltaY: y } = eventData;
       const absX = Math.abs(x);
       const transformAbsDistance =
-        Math.floor(absX / 4) + absX > SWIPE_THRESHOLD ? SWIPE_PADDING : 0;
+        Math.floor(absX) + absX > SWIPE_THRESHOLD ? SWIPE_PADDING : 0;
       const transformDistance =
         x > 0 ? transformAbsDistance : -transformAbsDistance;
       target.style.transform = `translateX(${transformDistance}px)`;

--- a/src/components/flashcard/main/swipe-action.tsx
+++ b/src/components/flashcard/main/swipe-action.tsx
@@ -26,7 +26,7 @@ export function SwipeActionText({ direction, active, children }: Props) {
     >
       <div
         className={cn(
-          "rounded-md bg-background px-8 py-4 text-muted transition duration-300",
+          "rounded-md px-8 py-4 text-muted transition duration-300",
           active && "animate-wiggle text-primary",
         )}
       >


### PR DESCRIPTION
- **feat: decrease swipe threshold**
- **feat: create placeholder element for card on swipe**

Fixed the scroll issues by (1) setting `overflow: hidden` on the main container.
(2) Creating a "placeholder" element that takes the space of the card on swipe.
This prevents layout shifts from occurring.

One added advantage of this approach is that we can even style the placeholder element, giving it a subtle `muted` background colour with low opacity.