### PR TITLE
Undo with optimistic updates

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,10 +34,10 @@ async function RootLayout({
           inter.variable,
         )}
       >
-        <SpeedInsights />
         <AuthSessionProvider session={session}>
           <ClientLayout>{children}</ClientLayout>
         </AuthSessionProvider>
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default async function Home() {
   const session = await auth();
 
   return (
-    <main className={cn(gridChildContentGrid, "h-full")}>
+    <main className={cn(gridChildContentGrid, "place-self-stretch")}>
       {session ? <FlashcardBox /> : <PleaseSignIn />}
     </main>
   );

--- a/src/components/flashcard/create-flashcard-form.tsx
+++ b/src/components/flashcard/create-flashcard-form.tsx
@@ -68,6 +68,7 @@ export default function CreateFlashcardForm() {
       form.reset();
       setMarkdownEditorKey(crypto.randomUUID());
     } catch (err) {
+      console.error(err);
       toast.error("Failed to create card");
     }
   };

--- a/src/components/flashcard/main/flashcard-menu-bar.tsx
+++ b/src/components/flashcard/main/flashcard-menu-bar.tsx
@@ -1,5 +1,6 @@
-import CardCountBadge from "@/components/flashcard/main/card-count-badge";
+import CreateFlashcardForm from "@/components/flashcard/create-flashcard-form";
 import FlashcardState from "@/components/flashcard/flashcard-state";
+import CardCountBadge from "@/components/flashcard/main/card-count-badge";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,6 +21,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { Kbd } from "@/components/ui/kbd";
 import { Toggle } from "@/components/ui/toggle";
 import {
   Tooltip,
@@ -27,8 +36,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useHistory } from "@/providers/history";
 import { SessionCard, SessionStats } from "@/utils/session";
 import { cn } from "@/utils/ui";
+import { format } from "date-fns";
 import _ from "lodash";
 import {
   ChevronsRight,
@@ -38,19 +49,7 @@ import {
   TrashIcon,
   Undo,
 } from "lucide-react";
-import { Kbd } from "@/components/ui/kbd";
-import CreateFlashcardForm from "@/components/flashcard/create-flashcard-form";
 import { useEffect, useState } from "react";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-import { format, intlFormatDistance } from "date-fns";
 
 type Props = {
   card: SessionCard;
@@ -75,8 +74,14 @@ export function FlashcardMenuBar({
   onUndo,
 }: Props) {
   const [cardFormOpen, setCardFormOpen] = useState(false);
+  const { isUndoing } = useHistory();
+  const disabled = isUndoing;
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (disabled) {
+        return;
+      }
       if (e.shiftKey && e.key === "ArrowRight") {
         onSkip();
       }
@@ -115,7 +120,7 @@ export function FlashcardMenuBar({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger className="cursor-text" onClick={onUndo}>
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" disabled={disabled}>
               <Undo className="h-6 w-6" strokeWidth={1.5} />
             </Button>
           </TooltipTrigger>
@@ -129,7 +134,7 @@ export function FlashcardMenuBar({
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger className="cursor-text" onClick={onSkip}>
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" disabled={disabled}>
               <ChevronsRight className="h-6 w-6" strokeWidth={1.5} />
             </Button>
           </TooltipTrigger>
@@ -145,6 +150,7 @@ export function FlashcardMenuBar({
           <TooltipTrigger className="cursor-text">
             <Toggle
               aria-label="toggle edit"
+              disabled={disabled}
               pressed={editing}
               onPressedChange={(isEditing) => {
                 if (!isEditing) {
@@ -172,6 +178,7 @@ export function FlashcardMenuBar({
                 className={cn(
                   buttonVariants({ variant: "ghost", size: "icon" }),
                 )}
+                disabled={disabled}
               >
                 <Info className="h-4 w-4" />
               </DrawerTrigger>
@@ -210,6 +217,7 @@ export function FlashcardMenuBar({
                 className={cn(
                   buttonVariants({ variant: "ghost", size: "icon" }),
                 )}
+                disabled={disabled}
               >
                 <Plus className="h-4 w-4" />
               </DialogTrigger>
@@ -240,6 +248,7 @@ export function FlashcardMenuBar({
                 className={cn(
                   buttonVariants({ variant: "outline", size: "icon" }),
                 )}
+                disabled={disabled}
               >
                 <TrashIcon className="h-4 w-4" strokeWidth={1.5} />
               </AlertDialogTrigger>

--- a/src/components/flashcard/main/flashcard-menu-bar.tsx
+++ b/src/components/flashcard/main/flashcard-menu-bar.tsx
@@ -100,7 +100,7 @@ export function FlashcardMenuBar({
     return () => {
       document.removeEventListener("keydown", handler);
     };
-  });
+  }, [disabled, onSkip, onDelete, setCardFormOpen, editing, setEditing]);
 
   return (
     <div className="col-span-8 flex h-24 flex-wrap items-end justify-center gap-x-2">
@@ -116,13 +116,21 @@ export function FlashcardMenuBar({
       {/* Separator */}
       <div className="mr-auto w-screen sm:w-0"></div>
 
-      {/* Icons */}
+      {/* Undo Button */}
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger className="cursor-text" onClick={onUndo}>
-            <Button variant="ghost" size="icon" disabled={disabled}>
-              <Undo className="h-6 w-6" strokeWidth={1.5} />
-            </Button>
+          <TooltipTrigger
+            onClick={onUndo}
+            className={cn(
+              "cursor-text",
+              buttonVariants({
+                variant: "ghost",
+                size: "icon",
+              }),
+            )}
+            disabled={disabled}
+          >
+            <Undo className="h-6 w-6" strokeWidth={1.5} />
           </TooltipTrigger>
           <TooltipContent className="flex flex-col items-center">
             <p>Undo</p>
@@ -131,12 +139,21 @@ export function FlashcardMenuBar({
         </Tooltip>
       </TooltipProvider>
 
+      {/* Suspend Button */}
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger className="cursor-text" onClick={onSkip}>
-            <Button variant="ghost" size="icon" disabled={disabled}>
-              <ChevronsRight className="h-6 w-6" strokeWidth={1.5} />
-            </Button>
+          <TooltipTrigger
+            onClick={onSkip}
+            className={cn(
+              "cursor-text",
+              buttonVariants({
+                variant: "ghost",
+                size: "icon",
+              }),
+            )}
+            disabled={disabled}
+          >
+            <ChevronsRight className="h-6 w-6" strokeWidth={1.5} />
           </TooltipTrigger>
           <TooltipContent className="flex flex-col items-center">
             <p>Suspend</p>
@@ -147,7 +164,7 @@ export function FlashcardMenuBar({
 
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger className="cursor-text">
+          <TooltipTrigger className="cursor-text" asChild>
             <Toggle
               aria-label="toggle edit"
               disabled={disabled}
@@ -170,10 +187,11 @@ export function FlashcardMenuBar({
         </Tooltip>
       </TooltipProvider>
 
+      {/* Info Button */}
       <Drawer direction="right">
         <TooltipProvider>
           <Tooltip>
-            <TooltipTrigger className="cursor-text">
+            <TooltipTrigger className="cursor-text" asChild>
               <DrawerTrigger
                 className={cn(
                   buttonVariants({ variant: "ghost", size: "icon" }),
@@ -209,10 +227,11 @@ export function FlashcardMenuBar({
         </DrawerContent>
       </Drawer>
 
+      {/* New Card Button */}
       <Dialog open={cardFormOpen} onOpenChange={setCardFormOpen}>
         <TooltipProvider>
           <Tooltip>
-            <TooltipTrigger className="cursor-text">
+            <TooltipTrigger className="cursor-text" asChild>
               <DialogTrigger
                 className={cn(
                   buttonVariants({ variant: "ghost", size: "icon" }),
@@ -240,10 +259,11 @@ export function FlashcardMenuBar({
         </DialogContent>
       </Dialog>
 
+      {/* Delete Button */}
       <AlertDialog>
         <TooltipProvider>
           <Tooltip>
-            <TooltipTrigger className="cursor-text">
+            <TooltipTrigger className="cursor-text" asChild>
               <AlertDialogTrigger
                 className={cn(
                   buttonVariants({ variant: "outline", size: "icon" }),

--- a/src/components/flashcard/main/flashcard.tsx
+++ b/src/components/flashcard/main/flashcard.tsx
@@ -209,7 +209,6 @@ export default function Flashcard({
     cardContainerRef.current = el;
   };
 
-  useKeydownRating(onRating, open && !editing, () => setOpen(true));
   useClickOutside({
     ref: cardContainerRef,
     enabled: editing,
@@ -305,6 +304,7 @@ export default function Flashcard({
           open={open}
           setOpen={setOpen}
           focusedRating={currentlyFocusedRating}
+          disabled={editing || !open}
         />
       </div>
     </div>

--- a/src/components/flashcard/main/flashcard.tsx
+++ b/src/components/flashcard/main/flashcard.tsx
@@ -106,7 +106,7 @@ export default function Flashcard({
   const { card_contents: initialCardContent } = sessionCard;
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState(false);
-  const cardContainerRef = useRef<HTMLDivElement>(null);
+  const cardContainerRef = useRef<HTMLDivElement | null>(null);
   const placeholderRef = useRef<HTMLDivElement>(null);
 
   const answerButtonsContainerRef = useRef<HTMLDivElement>(null);
@@ -200,6 +200,15 @@ export default function Flashcard({
     preventScrollOnSwipe: true,
   });
 
+  // https://www.npmjs.com/package/react-swipeable#how-to-share-ref-from-useswipeable
+  const cardContainerRefPassthrough = (el: HTMLDivElement | null) => {
+    handlers.ref(el);
+    if (!el) {
+      return;
+    }
+    cardContainerRef.current = el;
+  };
+
   useKeydownRating(onRating, open && !editing, () => setOpen(true));
   useClickOutside({
     ref: cardContainerRef,
@@ -218,10 +227,7 @@ export default function Flashcard({
   }, [open]);
 
   return (
-    <div
-      className="relative col-span-12 flex flex-col gap-x-4 gap-y-2 overflow-hidden"
-      ref={cardContainerRef}
-    >
+    <div className="relative col-span-12 flex flex-col gap-x-4 gap-y-2 overflow-hidden">
       {currentlyFocusedRating === "Good" && (
         <ThumbsUp className="absolute bottom-0 left-0 right-0 top-0 z-20 mx-auto my-auto h-12 w-12 animate-tada text-primary" />
       )}
@@ -275,6 +281,7 @@ export default function Flashcard({
             onRating("Good");
           }, 600);
         }}
+        ref={cardContainerRefPassthrough}
       >
         <EditableFlashcard
           form={form}

--- a/src/components/flashcard/main/rating-buttons.tsx
+++ b/src/components/flashcard/main/rating-buttons.tsx
@@ -7,6 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import useKeydownRating from "@/hooks/use-keydown-rating";
 import { Rating } from "@/schema";
 import { cn } from "@/utils/ui";
 import { intlFormatDistance } from "date-fns";
@@ -17,6 +18,7 @@ type Props = {
   onRating: (rating: Rating) => void;
   open: boolean;
   setOpen: (open: boolean) => void;
+  disabled: boolean;
 };
 
 function RatingButton({
@@ -62,8 +64,10 @@ export default function RatingButtons({
   open,
   setOpen,
   focusedRating: beforeRating,
+  disabled
 }: Props) {
   const ratingsToShow: Rating[] = ["Again", "Hard", "Good", "Easy"];
+  useKeydownRating(onRating, disabled, () => setOpen(true));
 
   return (
     <div

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -25,7 +25,7 @@ import {
 import { gfm } from "@milkdown/preset-gfm";
 import type { Node } from "@milkdown/prose/model";
 import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react";
-import { useEffect, useRef } from "react";
+import { forwardRef, useEffect, useRef } from "react";
 
 type Props = {
   value: string;
@@ -202,12 +202,12 @@ const MilkdownEditor = ({ disabled, value, onChange, border }: Props) => {
 
 MilkdownEditor.displayName = "MilkdownEditor";
 
-export const MarkdownEditor = (props: Props) => {
+export const MarkdownEditor = forwardRef((props: Props, _ref) => {
   return (
     <MilkdownProvider>
       <MilkdownEditor {...props} />
     </MilkdownProvider>
   );
-};
+});
 
 MarkdownEditor.displayName = "MarkdownEditor";

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -118,7 +118,7 @@ export function NavigationBar() {
   const session = useSession();
 
   return (
-    <NavigationMenu className="col-start-1 col-end-13 h-16 px-4 md:px-6 xl:col-start-3 xl:col-end-11">
+    <NavigationMenu className="col-start-1 col-end-13 h-16 px-4 md:px-0 xl:col-start-3 xl:col-end-11">
       <MenuDrawer />
 
       <NavigationMenuList className="hidden md:flex">

--- a/src/components/ui/grid.ts
+++ b/src/components/ui/grid.ts
@@ -4,7 +4,7 @@
 import { cn } from "@/utils/ui";
 
 export const grid = "grid grid-cols-12 gap-x-6 items-start";
-export const baseGrid = cn(grid);
+export const baseGrid = cn(grid, "px-2 md:px-4 xl:px-0");
 export const gridChild = "col-start-1 col-end-13";
 
 /**

--- a/src/hooks/use-keydown-rating.ts
+++ b/src/hooks/use-keydown-rating.ts
@@ -7,15 +7,20 @@ import { useEffect } from "react";
  */
 export default function useKeydownRating(
   onRating: (rating: Rating) => void,
-  open: boolean,
+  disabled: boolean,
   onOpen: () => void,
 ) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!open && event.key === " ") {
+      if (disabled && event.key === " ") {
         onOpen();
         return;
       }
+
+      if (disabled) {
+        return;
+      }
+
       const rating = KEY_TO_RATING[event.key];
       if (!rating) {
         return;
@@ -27,5 +32,5 @@ export default function useKeydownRating(
     return () => {
       window.removeEventListener("keyup", handleKeyDown);
     };
-  }, [onRating, open, onOpen]);
+  }, [onRating, disabled, onOpen]);
 }

--- a/src/providers/history.tsx
+++ b/src/providers/history.tsx
@@ -97,7 +97,6 @@ export function HistoryProvider({ children }: PropsWithChildren<{}>) {
     // The re-render might take some time
     // We do this to avoid the odd behaviour of the toast updating
     // but the card not yet updating
-    await new Promise((resolve) => setTimeout(resolve, 1000));
   };
 
   const undoCreate = async (entry: HistoryStateEntry) => {

--- a/src/server/routers/card.ts
+++ b/src/server/routers/card.ts
@@ -166,7 +166,7 @@ async function checkIfDecksBelongToUser(
 
   const foundDecks = await db.query.decks.findMany({
     where: and(
-      eq(users.id, user.id),
+      eq(decks.userId, user.id),
       inArray(decks.id, deckIds),
       eq(decks.deleted, false),
     ),

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -33,7 +33,6 @@ export type SessionData = {
 /**
  * Computes the next session data after grading a card.
  *
- * Preconditions: The card is in the session data.
  * If the card's state is `New`, then the card exists in `newCards`.
  * If the card is any oher state, then the card exists in `reviewCards`.
  *
@@ -48,7 +47,7 @@ export function removeCardFromSessionData(
   // As such, we can assume that we won't see the card again in the current deck.
   const card = getSessionCard(data, cardId);
   if (!card) {
-    throw new Error(`Card with id ${cardId} not found in session data`);
+    return data;
   }
 
   const nextData = produce(data, (draft) => {
@@ -86,9 +85,15 @@ function addCardToSessionData(
 ): SessionData {
   const nextData = produce(data, (draft) => {
     if (card.cards.state === "New") {
-      draft.newCards.push(card);
+      const positionToInsert = draft.newCards.findIndex(
+        (draftCard) => draftCard.cards.createdAt >= card.cards.createdAt,
+      );
+      draft.newCards.splice(positionToInsert, 0, card);
     } else {
-      draft.reviewCards.push(card);
+      const positionToInsert = draft.reviewCards.findIndex(
+        (draftCard) => draftCard.cards.difficulty >= card.cards.difficulty,
+      );
+      draft.reviewCards.splice(positionToInsert, 0, card);
     }
 
     switch (card.cards.state) {


### PR DESCRIPTION
Fixes #78
Fixes #82

Note: we still haven't handled optimistic updates with edit yet.
This is because we're currently using the cardId as the key to re-render the flashcard.

- **fix: fix grid styling**
- **fix: fix click outside to turn off edit**
- **feat: add optimistic updates for undo operations**
- **refactor: move keydown rating to answer buttons**
- **fix: resolve errors in console**
- **fix: fix issue with creating new card**
