### PR TITLE
Add custom obsidian plugin integration

### DIFF
--- a/src/components/flashcard/create-many-flashcard-form.tsx
+++ b/src/components/flashcard/create-many-flashcard-form.tsx
@@ -98,7 +98,6 @@ export default function CreateManyFlashcardForm() {
       if (!(typeof content === "string")) {
         return {
           success: false,
-          action: OBSIDIAN_ACTION.INSERT_CARDS,
           data: "Invalid content type",
         };
       }
@@ -107,7 +106,6 @@ export default function CreateManyFlashcardForm() {
 
       return {
         success: true,
-        action: OBSIDIAN_ACTION.INSERT_CARDS,
       };
     },
   );

--- a/src/components/flashcard/create-many-flashcard-form.tsx
+++ b/src/components/flashcard/create-many-flashcard-form.tsx
@@ -16,6 +16,7 @@ import {
   createManyCardsFormSchema,
 } from "@/form";
 import { useCreateManyCard } from "@/hooks/card/use-create-many-card";
+import { useSubscribeObsidian } from "@/hooks/use-subscribe-obsidian";
 import { extractCardContentFromMarkdownString } from "@/utils/obsidian-parse";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/utils/ui";
@@ -89,6 +90,24 @@ export default function CreateManyFlashcardForm() {
     };
     reader.readAsText(file);
   };
+
+  const action = "insert-cards";
+  useSubscribeObsidian(action, async (content: unknown) => {
+    if (!(typeof content === "string")) {
+      return {
+        success: false,
+        action,
+        data: "Invalid content type",
+      };
+    }
+    const contents = extractCardContentFromMarkdownString(content);
+    append(contents);
+
+    return {
+      success: true,
+      action,
+    };
+  });
 
   return (
     <Form {...form}>

--- a/src/components/flashcard/create-many-flashcard-form.tsx
+++ b/src/components/flashcard/create-many-flashcard-form.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/form";
 import { useCreateManyCard } from "@/hooks/card/use-create-many-card";
 import { useSubscribeObsidian } from "@/hooks/use-subscribe-obsidian";
+import { OBSIDIAN_ACTION } from "@/utils/obsidian";
 import { extractCardContentFromMarkdownString } from "@/utils/obsidian-parse";
 import { trpc } from "@/utils/trpc";
 import { cn } from "@/utils/ui";
@@ -91,23 +92,25 @@ export default function CreateManyFlashcardForm() {
     reader.readAsText(file);
   };
 
-  const action = "insert-cards";
-  useSubscribeObsidian(action, async (content: unknown) => {
-    if (!(typeof content === "string")) {
-      return {
-        success: false,
-        action,
-        data: "Invalid content type",
-      };
-    }
-    const contents = extractCardContentFromMarkdownString(content);
-    append(contents);
+  useSubscribeObsidian(
+    OBSIDIAN_ACTION.INSERT_CARDS,
+    async (content: unknown) => {
+      if (!(typeof content === "string")) {
+        return {
+          success: false,
+          action: OBSIDIAN_ACTION.INSERT_CARDS,
+          data: "Invalid content type",
+        };
+      }
+      const contents = extractCardContentFromMarkdownString(content);
+      append(contents);
 
-    return {
-      success: true,
-      action,
-    };
-  });
+      return {
+        success: true,
+        action: OBSIDIAN_ACTION.INSERT_CARDS,
+      };
+    },
+  );
 
   return (
     <Form {...form}>

--- a/src/components/flashcard/main/flashcard-box.tsx
+++ b/src/components/flashcard/main/flashcard-box.tsx
@@ -4,6 +4,7 @@ import Flashcard from "@/components/flashcard/main/flashcard";
 import { useFlashcardSession } from "@/providers/flashcard-session";
 import { getReviewDateForEachRating } from "@/utils/fsrs";
 import { Bug, Telescope } from "lucide-react";
+import { useState } from "react";
 
 type Props = {};
 
@@ -18,6 +19,7 @@ export default function FlashcardBox({}: Props) {
     onSkip,
     onDelete,
   } = useFlashcardSession();
+  const [open, setOpen] = useState(false);
 
   if (isLoading) {
     return (
@@ -53,20 +55,28 @@ export default function FlashcardBox({}: Props) {
   const card = currentCard;
   const schemaRatingToReviewDay = getReviewDateForEachRating(card.cards);
 
+  // TODO created an updated_at field instead
+  const key = `${card.cards.id}-${card.card_contents.question}-${card.card_contents.answer}`;
+
   return (
     <>
       {
         // We trigger a full re-render when the card changes
         // Currently, there's no need to optimise the rendering
         <Flashcard
-          key={card.cards.id}
+          key={key}
           stats={stats}
           card={card}
           schemaRatingToReviewDay={schemaRatingToReviewDay}
-          onRating={(rating) => onRating(rating, card)}
+          onRating={(rating) => {
+            onRating(rating, card);
+            setOpen(false);
+          }}
           onEdit={(content) => onEdit(content, card)}
           onDelete={() => onDelete(card)}
           onSkip={() => onSkip(card)}
+          open={open}
+          setOpen={setOpen}
         />
       }
     </>

--- a/src/components/flashcard/main/flashcard.tsx
+++ b/src/components/flashcard/main/flashcard.tsx
@@ -18,7 +18,7 @@ import {
   ThumbsUp,
   Undo,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useSwipeable } from "react-swipeable";
 
@@ -31,6 +31,9 @@ type Props = {
   onEdit: (content: CardContentFormValues) => void;
   onSkip: () => void;
   onDelete: () => void;
+
+  open: boolean;
+  setOpen: (open: boolean) => void;
 };
 
 const SWIPE_THRESHOLD = 60;
@@ -101,9 +104,10 @@ export default function Flashcard({
   onEdit,
   onDelete,
   onSkip,
+  open,
+  setOpen,
 }: Props) {
   const { card_contents: initialCardContent } = sessionCard;
-  const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const cardContainerRef = useRef<HTMLDivElement | null>(null);
   const placeholderRef = useRef<HTMLDivElement>(null);

--- a/src/components/flashcard/main/flashcard.tsx
+++ b/src/components/flashcard/main/flashcard.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import RatingButtons from "@/components/flashcard/main/rating-buttons";
 import { EditableFlashcard } from "@/components/flashcard/main/editable-flashcard";
 import { FlashcardMenuBar } from "@/components/flashcard/main/flashcard-menu-bar";
+import RatingButtons from "@/components/flashcard/main/rating-buttons";
 import { SwipeActionText } from "@/components/flashcard/main/swipe-action";
 import { CardContentFormValues, cardContentFormSchema } from "@/form";
 import { useClickOutside } from "@/hooks/use-click-outside";
-import useKeydownRating from "@/hooks/use-keydown-rating";
 import { useHistory } from "@/providers/history";
 import { Rating, type Card } from "@/schema";
 import { SessionCard, SessionStats } from "@/utils/session";

--- a/src/components/flashcard/main/flashcard.tsx
+++ b/src/components/flashcard/main/flashcard.tsx
@@ -217,13 +217,6 @@ export default function Flashcard({
     },
   });
 
-  useEffect(() => {
-    if (!open) return;
-    answerButtonsContainerRef.current?.scrollIntoView({
-      behavior: "smooth",
-    });
-  }, [open]);
-
   return (
     <div className="relative col-span-12 flex flex-col gap-x-4 gap-y-2 overflow-hidden">
       {currentlyFocusedRating === "Good" && (

--- a/src/hooks/use-subscribe-obsidian.ts
+++ b/src/hooks/use-subscribe-obsidian.ts
@@ -1,0 +1,55 @@
+import {
+  OBSIDIAN_ORIGIN,
+  ObsidianActionResponse,
+  isMessageEventFromObsidian,
+  obsidianActionSchema,
+} from "@/utils/obsidian";
+import { useEffect } from "react";
+
+/**
+ * Subscribe to an action called from Obsidian.
+ * @param actionType The action type to subscribe to
+ * @param callback The callback to call when the action is received
+ */
+export function useSubscribeObsidian(
+  actionType: string,
+  callback: (
+    eventData: unknown,
+  ) => Promise<ObsidianActionResponse> | ObsidianActionResponse,
+) {
+  useEffect(() => {
+    const listener = async (event: MessageEvent) => {
+      if (!isMessageEventFromObsidian(event)) {
+        return;
+      }
+
+      const parsed = obsidianActionSchema.safeParse(event.data);
+      if (!parsed.success) {
+        const errorResponse = {
+          success: false,
+          data: parsed.error,
+        };
+        event.source.postMessage(errorResponse, {
+          targetOrigin: OBSIDIAN_ORIGIN,
+        });
+        return;
+      }
+
+      // We don't want to handle actions that are not the one we're looking for
+      const data = parsed.data;
+      if (!(data.action === actionType)) {
+        return;
+      }
+
+      const response = await callback(data.data);
+      event.source.postMessage(response, {
+        targetOrigin: OBSIDIAN_ORIGIN,
+      });
+    };
+
+    window.addEventListener("message", listener);
+    return () => {
+      window.removeEventListener("message", listener);
+    };
+  }, [actionType, callback]);
+}

--- a/src/hooks/use-subscribe-obsidian.ts
+++ b/src/hooks/use-subscribe-obsidian.ts
@@ -1,10 +1,13 @@
 import {
   OBSIDIAN_ORIGIN,
   ObsidianActionResponse,
+  ObsidianActionType,
   isMessageEventFromObsidian,
   obsidianActionSchema,
 } from "@/utils/obsidian";
 import { useEffect } from "react";
+
+type ResponseWithoutType = Omit<ObsidianActionResponse, "action">;
 
 /**
  * Subscribe to an action called from Obsidian.
@@ -12,10 +15,10 @@ import { useEffect } from "react";
  * @param callback The callback to call when the action is received
  */
 export function useSubscribeObsidian(
-  actionType: string,
+  actionType: ObsidianActionType,
   callback: (
     eventData: unknown,
-  ) => Promise<ObsidianActionResponse> | ObsidianActionResponse,
+  ) => Promise<ResponseWithoutType> | ResponseWithoutType,
 ) {
   useEffect(() => {
     const listener = async (event: MessageEvent) => {
@@ -28,6 +31,7 @@ export function useSubscribeObsidian(
         const errorResponse = {
           success: false,
           data: parsed.error,
+          action: actionType,
         };
         event.source.postMessage(errorResponse, {
           targetOrigin: OBSIDIAN_ORIGIN,
@@ -42,7 +46,8 @@ export function useSubscribeObsidian(
       }
 
       const response = await callback(data.data);
-      event.source.postMessage(response, {
+      const responseWithType = { ...response, action: actionType };
+      event.source.postMessage(responseWithType, {
         targetOrigin: OBSIDIAN_ORIGIN,
       });
     };

--- a/src/providers/flashcard-session.tsx
+++ b/src/providers/flashcard-session.tsx
@@ -191,7 +191,6 @@ export function FlashcardSessionProvider({
   useSubscribeObsidian(OBSIDIAN_ACTION.GET_CURRENT_CARD, () => {
     return {
       success: true,
-      action: OBSIDIAN_ACTION.GET_CURRENT_CARD,
       data: currentCard,
     };
   });

--- a/src/providers/flashcard-session.tsx
+++ b/src/providers/flashcard-session.tsx
@@ -1,4 +1,8 @@
-import { OBSIDIAN_ORIGIN, isMessageEventFromObsidian } from "@/utils/obsidian";
+import {
+  OBSIDIAN_ACTION,
+  OBSIDIAN_ORIGIN,
+  isMessageEventFromObsidian,
+} from "@/utils/obsidian";
 import { CardContentFormValues } from "@/form";
 import { useDeleteCard } from "@/hooks/card/use-delete-card";
 import { useEditCard } from "@/hooks/card/use-edit-card";
@@ -184,11 +188,10 @@ export function FlashcardSessionProvider({
     });
   };
 
-  const action = "get-current-card";
-  useSubscribeObsidian(action, () => {
+  useSubscribeObsidian(OBSIDIAN_ACTION.GET_CURRENT_CARD, () => {
     return {
       success: true,
-      action,
+      action: OBSIDIAN_ACTION.GET_CURRENT_CARD,
       data: currentCard,
     };
   });

--- a/src/providers/flashcard-session.tsx
+++ b/src/providers/flashcard-session.tsx
@@ -1,3 +1,4 @@
+import { OBSIDIAN_ORIGIN, isMessageEventFromObsidian } from "@/utils/obsidian";
 import { CardContentFormValues } from "@/form";
 import { useDeleteCard } from "@/hooks/card/use-delete-card";
 import { useEditCard } from "@/hooks/card/use-edit-card";
@@ -9,8 +10,9 @@ import { getReviewDateForEachRating } from "@/utils/fsrs";
 import { SessionCard, SessionData } from "@/utils/session";
 import { trpc } from "@/utils/trpc";
 import { intlFormatDistance } from "date-fns";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect } from "react";
 import { toast } from "sonner";
+import { useSubscribeObsidian } from "@/hooks/use-subscribe-obsidian";
 
 type FlashcardSession = {
   data: SessionData;
@@ -181,6 +183,15 @@ export function FlashcardSessionProvider({
       },
     });
   };
+
+  const action = "get-current-card";
+  useSubscribeObsidian(action, () => {
+    return {
+      success: true,
+      action,
+      data: currentCard,
+    };
+  });
 
   return (
     <FlashcardSessionContext.Provider

--- a/src/utils/obsidian.ts
+++ b/src/utils/obsidian.ts
@@ -26,7 +26,20 @@ export function isMessageEventFromObsidian(
   return true;
 }
 
-const OBSIDIAN_ACTION_TYPES = ["get-current-card", "insert-cards"] as const;
+export const OBSIDIAN_ACTION = {
+    GET_CURRENT_CARD: "get-current-card",
+    INSERT_CARDS: "insert-cards",
+    UPDATE_FRONT: "update-front",
+    UPDATE_BACK: "update-back",
+} as const;
+
+const OBSIDIAN_ACTION_TYPES = [
+    OBSIDIAN_ACTION.GET_CURRENT_CARD,
+    OBSIDIAN_ACTION.INSERT_CARDS,
+    OBSIDIAN_ACTION.UPDATE_FRONT,
+    OBSIDIAN_ACTION.UPDATE_BACK,
+] as const;
+
 export type ObsidianActionType = (typeof OBSIDIAN_ACTION_TYPES)[number];
 
 export const obsidianActionSchema = z.object({

--- a/src/utils/obsidian.ts
+++ b/src/utils/obsidian.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * The origin for the Obsidian app.
+ */
+export const OBSIDIAN_ORIGIN = "app://obsidian.md";
+
+export type MessageEventWithSource = MessageEvent & {
+  source: MessageEventSource;
+};
+
+export function isMessageEventFromObsidian(
+  event: MessageEvent,
+): event is MessageEventWithSource {
+  if (event.origin !== OBSIDIAN_ORIGIN) {
+    console.warn("Received message from unknown origin:", event.origin);
+    return false;
+  }
+
+  const canPostMessage = event.source && "postMessage" in event.source;
+  if (!canPostMessage) {
+    console.warn("Unable to post message to parent");
+    return false;
+  }
+
+  return true;
+}
+
+const OBSIDIAN_ACTION_TYPES = ["get-current-card", "insert-cards"] as const;
+export type ObsidianActionType = (typeof OBSIDIAN_ACTION_TYPES)[number];
+
+export const obsidianActionSchema = z.object({
+  action: z.enum(OBSIDIAN_ACTION_TYPES),
+  data: z.unknown(),
+});
+
+export type ObsidianAction = z.infer<typeof obsidianActionSchema>;
+
+export const obsidianActionResponseSchema = z.object({
+  success: z.boolean(),
+  action: z.enum(OBSIDIAN_ACTION_TYPES),
+  data: z.unknown().optional(),
+});
+export type ObsidianActionResponse = z.infer<
+  typeof obsidianActionResponseSchema
+>;


### PR DESCRIPTION
Fixes #79

This PR adds integration with a custom [Obsidian plugin](https://github.com/zsh-eng/obsidian-spaced) which I created.

Basic commands added include

- [x] Adding the contents of the current card into the editor
- [x] Sending current file to bulk card creation page
- [x] Edit the question / answer of a card

Future additions include:
1. Creating single card (with source)
2. Looking up cards with a specific source
3. Creating card with deck (based on settings tag - maintain a map of ids)
4. Looking up cards for a specific deck